### PR TITLE
Prevent GM:ChangeGametype from being called twice in GM:SetGametypeCVarByPrettyName

### DIFF
--- a/gamemodes/groundcontrolredux/gamemode/sh_gametypes.lua
+++ b/gamemodes/groundcontrolredux/gamemode/sh_gametypes.lua
@@ -34,7 +34,8 @@ function GM:SetGametypeCVarByPrettyName(targetName)
     local key, _ = self:GetGametypeFromConVar(targetName)
 
     if key then
-        self:ChangeGametype(key)
+        -- (afxnatic): We let the convar callback handle changing gametype, as it calls the exact same function
+        -- self:ChangeGametype(key)
         game.ConsoleCommand("gc_gametype " .. key .. "\n")
 
         return true


### PR DESCRIPTION
EG: when gametype vote finishes